### PR TITLE
Fix: Add mock user credentials hint to login screen

### DIFF
--- a/weight_loss_challenge/lib/screens/auth/login_screen.dart
+++ b/weight_loss_challenge/lib/screens/auth/login_screen.dart
@@ -149,7 +149,7 @@ class _LoginScreenState extends State<LoginScreen> {
                 // Help text
                 if (!_isLoading)
                   const Text(
-                    'Use test@example.com / password123',
+                    'For testing, use email: user1@example.com (any password will work)',
                     textAlign: TextAlign.center,
                     style: TextStyle(
                       fontSize: 12,


### PR DESCRIPTION
This commit adds a hint to the login screen with mock user credentials for easy testing. The previous hint was incorrect and did not reflect the mock data in the backend. The new hint provides a valid mock email and clarifies that any password will work for testing purposes.