### PR TITLE
feat: Update bottom navigation bar

### DIFF
--- a/weight_loss_challenge/lib/screens/app_shell.dart
+++ b/weight_loss_challenge/lib/screens/app_shell.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:weight_loss_challenge/screens/challenges/challenges_hub_screen.dart';
 import 'package:weight_loss_challenge/screens/home/dashboard_screen.dart';
-import 'package:weight_loss_challenge/screens/leaderboard/group_leaderboard_screen.dart';
+import 'package:weight_loss_challenge/screens/leaderboard/leaderboard_screen_new.dart';
 import 'package:weight_loss_challenge/screens/profile/profile_screen.dart';
 
 class AppShell extends StatefulWidget {
@@ -17,7 +17,7 @@ class _AppShellState extends State<AppShell> {
   static const List<Widget> _widgetOptions = <Widget>[
     DashboardScreen(),
     ChallengesHubScreen(),
-    GroupLeaderboardScreen(),
+    LeaderboardScreen(),
     ProfileScreen(),
   ];
 
@@ -41,11 +41,11 @@ class _AppShellState extends State<AppShell> {
           ),
           BottomNavigationBarItem(
             icon: Icon(Icons.emoji_events),
-            label: 'Challenges',
+            label: 'My Challenges',
           ),
           BottomNavigationBarItem(
             icon: Icon(Icons.leaderboard),
-            label: 'Leaderboard',
+            label: 'Leader Board',
           ),
           BottomNavigationBarItem(
             icon: Icon(Icons.person),


### PR DESCRIPTION
This commit updates the bottom navigation bar in the application to match the user's requirements.

The following changes have been made:
- The labels for the navigation items have been updated to "Dashboard", "My Challenges", and "Leader Board".
- The "Leaderboard" screen has been changed to a new screen that includes both individual and group leaderboards, accessible through tabs.
- The "Profile" tab has been kept as requested by the user.

This change also addresses the user's request for the content of the "My Challenges" and "Leader Board" screens.
- The "My Challenges" tab points to the `ChallengesHubScreen`, which already contains tabs for "Active" and "Completed" challenges.
- The "Leader Board" tab now points to the `LeaderboardScreen`, which contains tabs for "Individual" and "Group" leaderboards.