### PR TITLE
.+feat: Add auto-login for testing

### DIFF
--- a/weight_loss_challenge/lib/services/auth_service.dart
+++ b/weight_loss_challenge/lib/services/auth_service.dart
@@ -23,6 +23,11 @@ class AuthService {
 
   MockUser? get currentUser => _currentUser;
 
+  AuthService() {
+    // For testing purposes, automatically log in a user
+    signInWithEmailAndPassword('user2@example.com', 'anypassword');
+  }
+
   Future<MockUser?> createUserWithEmailAndPassword({
     required String email,
     required String password,


### PR DESCRIPTION
This commit adds an auto-login feature for testing purposes. The app will now automatically log in as the user `user2@example.com`, who has access to all challenges. This bypasses the login screen and makes testing easier.

This is achieved by adding a constructor to `AuthService` that calls `signInWithEmailAndPassword` on initialization.