### PR TITLE
fix: Prevent duplicate challenge creation

### DIFF
--- a/weight_loss_challenge/lib/services/challenge_service.dart
+++ b/weight_loss_challenge/lib/services/challenge_service.dart
@@ -56,7 +56,6 @@ class ChallengeService {
       entryWeightEndDate: entryWeightEndDate,
       finalWeightEndDate: finalWeightEndDate,
     );
-    _challenges.add(challenge);
     _challengesController.add(_challenges);
     return challenge;
   }


### PR DESCRIPTION
- Removed redundant code that was adding a newly created challenge to the local list in `ChallengeService`, as the API call already handles this.
- This resolves the issue where challenges were appearing twice after creation.