### PR TITLE
Fix: Prevent duplicate weight entries in challenges

### DIFF
--- a/weight_loss_challenge/lib/api/challenge_api.dart
+++ b/weight_loss_challenge/lib/api/challenge_api.dart
@@ -101,7 +101,7 @@ class ChallengeApi {
     _backend.challenges[index] = updatedChallenge;
   }
 
-  Future<void> addWeightEntry({
+  Future<WeightEntry> addWeightEntry({
     required String challengeId,
     required String userId,
     required double weight,
@@ -121,12 +121,14 @@ class ChallengeApi {
     if (!progress.containsKey(userId)) {
       progress[userId] = [];
     }
-    progress[userId]!.add(WeightEntry(weight: weight, timestamp: DateTime.now()));
+    final newEntry = WeightEntry(weight: weight, timestamp: DateTime.now());
+    progress[userId]!.add(newEntry);
 
     final updatedChallenge = challenge.copyWith(
       participantProgress: progress,
     );
     _backend.challenges[index] = updatedChallenge;
+    return newEntry;
   }
 
   Future<void> requestToJoinPublicChallenge(String challengeId, String userId) async {

--- a/weight_loss_challenge/lib/api/weight_api.dart
+++ b/weight_loss_challenge/lib/api/weight_api.dart
@@ -28,12 +28,8 @@ class WeightApi {
     );
 
     if (challengeId != null) {
-      final challenge =
-          _backend.challenges.firstWhere((c) => c.id == challengeId);
-      if (challenge.participantProgress[userId] == null) {
-        challenge.participantProgress[userId] = [];
-      }
-      challenge.participantProgress[userId]!.add(entry);
+      // The logic to add a weight entry to a challenge has been moved to
+      // ChallengeApi.addWeightEntry to avoid duplicate entries.
     }
 
     return entry;

--- a/weight_loss_challenge/lib/providers/app_state.dart
+++ b/weight_loss_challenge/lib/providers/app_state.dart
@@ -174,17 +174,10 @@ class AppState extends ChangeNotifier {
     if (currentUser == null) throw Exception('Not authenticated');
 
     // Add weight entry to the challenge
-    await _challengeService.addWeightEntry(
+    final entry = await _challengeService.addWeightEntry(
       challengeId: challengeId,
       userId: currentUser!.id,
       weight: weight,
-    );
-
-    // Also record it in the user's weight history
-    final entry = await _weightService.addWeightEntry(
-      userId: currentUser!.id,
-      weight: weight,
-      challengeId: challengeId,
     );
 
     notifyListeners();

--- a/weight_loss_challenge/lib/services/challenge_service.dart
+++ b/weight_loss_challenge/lib/services/challenge_service.dart
@@ -70,17 +70,18 @@ class ChallengeService {
     await refreshChallenges(userId);
   }
 
-  Future<void> addWeightEntry({
+  Future<WeightEntry> addWeightEntry({
     required String challengeId,
     required String userId,
     required double weight,
   }) async {
-    await _api.addWeightEntry(
+    final entry = await _api.addWeightEntry(
       challengeId: challengeId,
       userId: userId,
       weight: weight,
     );
     await refreshChallenges(userId);
+    return entry;
   }
 
   Future<void> requestToJoinPublicChallenge(String challengeId, String userId) async {


### PR DESCRIPTION
This commit fixes a bug where adding a weight entry within a challenge would result in the creation of two identical entries.

The root cause of this issue was in `AppState.addWeightEntry`, which was calling both `_challengeService.addWeightEntry` and `_weightService.addWeightEntry`. Both of these services were then writing to the same mock backend data structure, leading to the duplication.

The following changes have been made to resolve this issue:

1.  The redundant call to `_weightService.addWeightEntry` has been removed from `AppState.addWeightEntry`.
2.  The `addWeightEntry` methods in `ChallengeApi` and `ChallengeService` have been refactored to return the newly created `WeightEntry` object, ensuring that the `AppState` method can still return the entry as it did before.
3.  The logic for adding a weight entry to a challenge has been removed from `WeightApi.addWeightEntry` to improve the separation of concerns and prevent this kind of bug from happening in the future.